### PR TITLE
Add variable supporting service access principals

### DIFF
--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -63,6 +63,7 @@ No requirements.
 | <a name="input_advanced_common_roles"></a> [advanced\_common\_roles](#input\_advanced\_common\_roles) | List of roles that should be present in all accounts | `list(string)` | <pre>[<br/>  "admin",<br/>  "developer",<br/>  "read-only"<br/>]</pre> | no |
 | <a name="input_dangerous_close_on_deletion"></a> [dangerous\_close\_on\_deletion](#input\_dangerous\_close\_on\_deletion) | Close sub-acounts on deletion | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The alias for the AWS account | `string` | n/a | yes |
+| <a name="input_service_access_principals_enabled"></a> [service\_access\_principals\_enabled](#input\_service\_access\_principals\_enabled) | Enable service access principals for the organization. additional\_service\_principals can be used to add more service principals. | <pre>object({<br/>    account = optional(bool, true)<br/>    sso     = optional(bool, true)<br/><br/>    additional_service_principals = optional(list(string), [])<br/>  })</pre> | `{}` | no |
 | <a name="input_sub_accounts"></a> [sub\_accounts](#input\_sub\_accounts) | A list of sub-accounts to create (name, email) | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/organization/org.tf
+++ b/modules/organization/org.tf
@@ -1,5 +1,13 @@
 resource "aws_organizations_organization" "this" {
   feature_set = "ALL"
+
+  aws_service_access_principals = concat(
+    var.service_access_principals_enabled.additional_service_principals,
+    [
+      var.service_access_principals_enabled.sso ? "sso.amazonaws.com" : null,
+      var.service_access_principals_enabled.account ? "account.amazonaws.com" : null,
+    ],
+  )
 }
 
 resource "aws_organizations_account" "account" {

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -30,3 +30,14 @@ variable "dangerous_close_on_deletion" {
   type        = bool
   default     = false
 }
+
+variable "service_access_principals_enabled" {
+  description = "Enable service access principals for the organization. additional_service_principals can be used to add more service principals."
+  type = object({
+    account = optional(bool, true)
+    sso     = optional(bool, true)
+
+    additional_service_principals = optional(list(string), [])
+  })
+  default = {}
+}


### PR DESCRIPTION
The service access principals can be anbled by the orgnization and not having it is causing drift on resource.