### PR TITLE
Add GitHub OIDC configuration

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,0 +1,19 @@
+name: Generate terraform docs
+on:
+  - pull_request
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@v1.4.1
+        with:
+          recursive: true
+          recursive-path: modules
+          output-file: README.md
+          output-method: inject
+          git-push: "true"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -12,8 +12,7 @@ jobs:
       - name: Render terraform docs inside the README.md and push changes back to PR branch
         uses: terraform-docs/gh-actions@v1.4.1
         with:
-          recursive: true
-          recursive-path: modules
+          find-dir: "modules"
           output-file: README.md
           output-method: inject
           git-push: "true"

--- a/README.md
+++ b/README.md
@@ -1,26 +1,2 @@
 # tf-aws-iam
-<!-- BEGIN_TF_DOCS -->
-## Requirements
 
-No requirements.
-
-## Providers
-
-No providers.
-
-## Modules
-
-No modules.
-
-## Resources
-
-No resources.
-
-## Inputs
-
-No inputs.
-
-## Outputs
-
-No outputs.
-<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # tf-aws-iam
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -1,39 +1,15 @@
-## Requirements
+# GitHub OpenID Connect provider module
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+The module simplifies the configuration of the aws_iam_openid_connect_provider for connecting through GitHub Actions.
 
-## Providers
+## Example
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+```hcl
+module "github_oidc_provider" {
+  source = "github.com/letsgodevops/terraform-aws-iam//modules/github-oidc-provider?ref=v0.2.0"
+}
 
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
-| [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-
-## Outputs
-
-No outputs.
-
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -1,0 +1,35 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.

--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -33,3 +33,41 @@ No modules.
 ## Outputs
 
 No outputs.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/github-oidc-provider/README.md
+++ b/modules/github-oidc-provider/README.md
@@ -1,6 +1,6 @@
 # GitHub OpenID Connect provider module
 
-The module simplifies the configuration of the aws_iam_openid_connect_provider for connecting through GitHub Actions.
+The module simplifies the configuration of the `aws_iam_openid_connect_provider` for connecting through GitHub Actions.
 
 ## Example
 
@@ -8,8 +8,8 @@ The module simplifies the configuration of the aws_iam_openid_connect_provider f
 module "github_oidc_provider" {
   source = "github.com/letsgodevops/terraform-aws-iam//modules/github-oidc-provider?ref=v0.2.0"
 }
-
 ```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -1,0 +1,17 @@
+locals {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "tls_certificate" "this" {
+  url = local.url
+}
+
+resource "aws_iam_openid_connect_provider" "this" {
+  url            = local.url
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    for cert in data.tls_certificate.this.certificates : cert.sha1_fingerprint if cert.is_ca
+  ]
+
+  tags = var.tags
+}

--- a/modules/github-oidc-provider/providers.tf
+++ b/modules/github-oidc-provider/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/github-oidc-provider/variables.tf
+++ b/modules/github-oidc-provider/variables.tf
@@ -1,0 +1,6 @@
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+

--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -1,0 +1,47 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.github_ecr_push_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.github_ecr_push_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.multiple](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.github_ecr_push_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled         = optional(bool, true)<br/>    repository_arns = optional(list(string), ["*"])<br/>    kms_key_aliases = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
+| <a name="input_iam_path"></a> [iam\_path](#input\_iam\_path) | IAM path for OIDC role | `string` | `"/oidc/"` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | IAM role name | `string` | n/a | yes |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role | `number` | `3600` | no |
+| <a name="input_policy_arn"></a> [policy\_arn](#input\_policy\_arn) | IAM policy arn for OIDC role | `string` | `null` | no |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | IAM policy arns for OIDC role | `list(string)` | `[]` | no |
+| <a name="input_subject_values"></a> [subject\_values](#input\_subject\_values) | Values for trust relationship conditions. See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role |

--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -1,3 +1,45 @@
+# GitHub OpenID Connect role module
+
+The module to create pre-configured AWS IAM role to work with GitHub Actions.
+
+## Example
+
+```hcl
+module "github_oidc_role" {
+  source = "github.com/letsgodevops/terraform-aws-iam//modules/github-oidc-role?ref=v0.2.0"
+
+  iam_role_name = "github-actions-role"
+
+  ecr_push_policy = {
+    repositories = [
+      aws_ecr_repository.my_repo.arn,
+    ]
+  }
+
+  subject_values = [
+    "repo:letsgodevops/terraform-aws-iam:*",
+  ]
+}
+```
+
+## Subject values
+
+Subject values are delivered to the policy allowing the use of the IAM role. Please tak a look at [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims) for more subject value examples. tldr:
+
+```
+# all pull requests
+repo:octo-org/octo-repo:pull_request
+
+# branch specific
+repo:octo-org/octo-repo:ref:refs/heads/demo-branch
+
+# tag specific
+repo:octo-org/octo-repo:ref:refs/tags/demo-tag
+
+# environment
+repo:octo-org/octo-repo:environment:production
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -39,7 +81,7 @@ No modules.
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role | `number` | `3600` | no |
 | <a name="input_policy_arn"></a> [policy\_arn](#input\_policy\_arn) | IAM policy arn for OIDC role | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | IAM policy arns for OIDC role | `list(string)` | `[]` | no |
-| <a name="input_subject_values"></a> [subject\_values](#input\_subject\_values) | Values for trust relationship conditions. See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims | `list(string)` | n/a | yes |
+| <a name="input_subject_values"></a> [subject\_values](#input\_subject\_values) | Values for trust relationship conditions. See <https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims> | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -45,3 +46,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role |
+<!-- END_TF_DOCS -->

--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -81,7 +81,7 @@ No modules.
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role | `number` | `3600` | no |
 | <a name="input_policy_arn"></a> [policy\_arn](#input\_policy\_arn) | IAM policy arn for OIDC role | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | IAM policy arns for OIDC role | `list(string)` | `[]` | no |
-| <a name="input_subject_values"></a> [subject\_values](#input\_subject\_values) | Values for trust relationship conditions. See <https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims> | `list(string)` | n/a | yes |
+| <a name="input_subject_values"></a> [subject\_values](#input\_subject\_values) | Values for trust relationship conditions. See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/modules/github-oidc-role/ecr-policy.tf
+++ b/modules/github-oidc-role/ecr-policy.tf
@@ -1,0 +1,49 @@
+data "aws_iam_policy_document" "github_ecr_push_policy" {
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+
+    resources = var.ecr_push_policy.repository_arns
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["ecr:GetAuthorizationToken"]
+  }
+
+  statement {
+    actions   = ["kms:GenerateDataKey"]
+    resources = ["arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"]
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:ResourceAliases"
+      values   = var.ecr_push_policy.kms_key_aliases
+    }
+  }
+}
+
+resource "aws_iam_policy" "github_ecr_push_policy" {
+  count       = var.ecr_push_policy.enabled ? 1 : 0
+  name        = "github-ecr-push-policy"
+  description = "Policy for GitHub Actions to push to ECR"
+  policy      = data.aws_iam_policy_document.github_ecr_push_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_ecr_push_policy" {
+  count      = var.ecr_push_policy.enabled ? 1 : 0
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.github_ecr_push_policy[0].arn
+}

--- a/modules/github-oidc-role/main.tf
+++ b/modules/github-oidc-role/main.tf
@@ -1,0 +1,53 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        format(
+          "arn:aws:iam::%s:oidc-provider/token.actions.githubusercontent.com",
+          data.aws_caller_identity.current.account_id,
+        )
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = var.subject_values
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name                 = var.iam_role_name
+  path                 = var.iam_path
+  assume_role_policy   = data.aws_iam_policy_document.this.json
+  max_session_duration = var.max_session_duration
+
+  tags = {
+    Creator = "terraform"
+    Type    = "oidc"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count      = var.policy_arn != null ? 1 : 0
+  role       = aws_iam_role.this.name
+  policy_arn = var.policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "multiple" {
+  count      = length(var.policy_arns)
+  role       = aws_iam_role.this.name
+  policy_arn = element(var.policy_arns, count.index)
+}

--- a/modules/github-oidc-role/outputs.tf
+++ b/modules/github-oidc-role/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "The ARN of the IAM role"
+  value       = aws_iam_role.this.arn
+}

--- a/modules/github-oidc-role/providers.tf
+++ b/modules/github-oidc-role/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/github-oidc-role/variables.tf
+++ b/modules/github-oidc-role/variables.tf
@@ -1,0 +1,43 @@
+variable "iam_role_name" {
+  description = "IAM role name"
+  type        = string
+}
+
+variable "iam_path" {
+  description = "IAM path for OIDC role"
+  type        = string
+  default     = "/oidc/"
+}
+
+variable "policy_arn" {
+  description = "IAM policy arn for OIDC role"
+  type        = string
+  default     = null
+}
+
+variable "policy_arns" {
+  description = "IAM policy arns for OIDC role"
+  type        = list(string)
+  default     = []
+}
+
+variable "subject_values" {
+  description = "Values for trust relationship conditions. See https://docs.github.com/en/actions/reference/security/oidc#example-subject-claims"
+  type        = list(string)
+}
+
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the specified role"
+  type        = number
+  default     = 3600
+}
+
+variable "ecr_push_policy" {
+  description = "ECR push policy configuration for GitHub Actions OIDC role"
+  type = object({
+    enabled         = optional(bool, true)
+    repository_arns = optional(list(string), ["*"])
+    kms_key_aliases = optional(list(string), ["alias/aws/ecr"])
+  })
+  default = {}
+}


### PR DESCRIPTION
This pull request introduces modules designed to streamline the creation of an AWS IAM role tailored for integration with a GitHub repository. The modules automate the configuration process, ensuring secure and efficient setup of the necessary permissions for GitHub actions to interact with AWS resources.