### PR TITLE
Add optional public-ecr policy

### DIFF
--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -75,7 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled         = optional(bool, true)<br/>    repository_arns = optional(list(string), ["*"])<br/>    kms_key_aliases = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
+| <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled                = optional(bool, true)<br/>    repository_arns        = optional(list(string), ["*"])<br/>    public_repository_arns = optional(list(string), [])<br/>    kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
 | <a name="input_iam_path"></a> [iam\_path](#input\_iam\_path) | IAM path for OIDC role | `string` | `"/oidc/"` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | IAM role name | `string` | n/a | yes |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role | `number` | `3600` | no |

--- a/modules/github-oidc-role/ecr-policy.tf
+++ b/modules/github-oidc-role/ecr-policy.tf
@@ -17,10 +17,35 @@ data "aws_iam_policy_document" "github_ecr_push_policy" {
     resources = var.ecr_push_policy.repository_arns
   }
 
+  dynamic "statement" {
+    for_each = length(var.ecr_push_policy.public_repository_arns) > 0 ? [1] : []
+
+    content {
+      sid = "AllowECRPublicActions"
+
+      actions = [
+        "ecr-public:BatchCheckLayerAvailability",
+        "ecr-public:DescribeImages",
+        "ecr-public:GetRepositoryPolicy",
+        "ecr-public:PutImage",
+        "ecr-public:InitiateLayerUpload",
+        "ecr-public:UploadLayerPart",
+        "ecr-public:CompleteLayerUpload",
+        "ecr-public:DescribeRepositories",
+      ]
+
+      resources = var.ecr_push_policy.public_repository_arns
+    }
+  }
+
   statement {
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["ecr:GetAuthorizationToken"]
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr-public:GetAuthorizationToken",
+    ]
   }
 
   statement {

--- a/modules/github-oidc-role/variables.tf
+++ b/modules/github-oidc-role/variables.tf
@@ -35,9 +35,10 @@ variable "max_session_duration" {
 variable "ecr_push_policy" {
   description = "ECR push policy configuration for GitHub Actions OIDC role"
   type = object({
-    enabled         = optional(bool, true)
-    repository_arns = optional(list(string), ["*"])
-    kms_key_aliases = optional(list(string), ["alias/aws/ecr"])
+    enabled                = optional(bool, true)
+    repository_arns        = optional(list(string), ["*"])
+    public_repository_arns = optional(list(string), [])
+    kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])
   })
   default = {}
 }


### PR DESCRIPTION
The public ecr does not share actions with private repositories. Need to add policy conditionally.