### PR TITLE
fix(github-oidc-role): fix ECR push policy name collision on multiple module instances

### DIFF
--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -75,7 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled                = optional(bool, true)<br/>    repository_arns        = optional(list(string), ["*"])<br/>    public_repository_arns = optional(list(string), [])<br/>    kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
+| <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled                = optional(bool, true)<br/>    policy_name            = optional(string, null)<br/>    repository_arns        = optional(list(string), ["*"])<br/>    public_repository_arns = optional(list(string), [])<br/>    kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
 | <a name="input_iam_path"></a> [iam\_path](#input\_iam\_path) | IAM path for OIDC role | `string` | `"/oidc/"` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | IAM role name | `string` | n/a | yes |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role | `number` | `3600` | no |

--- a/modules/github-oidc-role/ecr-policy.tf
+++ b/modules/github-oidc-role/ecr-policy.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "github_ecr_push_policy" {
 
 resource "aws_iam_policy" "github_ecr_push_policy" {
   count       = var.ecr_push_policy.enabled ? 1 : 0
-  name        = "github-ecr-push-policy"
+  name        = var.ecr_push_policy.policy_name != null ? var.ecr_push_policy.policy_name : "${var.iam_role_name}-ecr-push-policy"
   description = "Policy for GitHub Actions to push to ECR"
   policy      = data.aws_iam_policy_document.github_ecr_push_policy.json
 }

--- a/modules/github-oidc-role/variables.tf
+++ b/modules/github-oidc-role/variables.tf
@@ -36,6 +36,7 @@ variable "ecr_push_policy" {
   description = "ECR push policy configuration for GitHub Actions OIDC role"
   type = object({
     enabled                = optional(bool, true)
+    policy_name            = optional(string, null)
     repository_arns        = optional(list(string), ["*"])
     public_repository_arns = optional(list(string), [])
     kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])


### PR DESCRIPTION
  ### Problem
When instantiating the `github-oidc-role` module more than once in the same AWS account, Terraform fails because both instances attempt to create an IAM policy named `github-ecr-push-policy`.

### Solution
The ECR push policy name now defaults to `<iam_role_name>-ecr-push-policy`. An optional `ecr_push_policy.policy_name` field is available for explicit overrides.

### Changes
- `variables.tf`: added `policy_name = optional(string, null)` to `ecr_push_policy` object
- `ecr-policy.tf`: replaced hardcoded policy name with dynamic value