### PR TITLE
feat(github-oidc-role): support additional OIDC trust policy conditions

### DIFF
--- a/modules/github-oidc-role/README.md
+++ b/modules/github-oidc-role/README.md
@@ -75,6 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_conditions"></a> [additional\_conditions](#input\_additional\_conditions) | Additional conditions for the OIDC trust policy, e.g. job\_workflow\_ref restrictions | <pre>list(object({<br/>    test     = string<br/>    variable = string<br/>    values   = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_ecr_push_policy"></a> [ecr\_push\_policy](#input\_ecr\_push\_policy) | ECR push policy configuration for GitHub Actions OIDC role | <pre>object({<br/>    enabled                = optional(bool, true)<br/>    policy_name            = optional(string, null)<br/>    repository_arns        = optional(list(string), ["*"])<br/>    public_repository_arns = optional(list(string), [])<br/>    kms_key_aliases        = optional(list(string), ["alias/aws/ecr"])<br/>  })</pre> | `{}` | no |
 | <a name="input_iam_path"></a> [iam\_path](#input\_iam\_path) | IAM path for OIDC role | `string` | `"/oidc/"` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | IAM role name | `string` | n/a | yes |

--- a/modules/github-oidc-role/main.tf
+++ b/modules/github-oidc-role/main.tf
@@ -25,6 +25,15 @@ data "aws_iam_policy_document" "this" {
       variable = "token.actions.githubusercontent.com:aud"
       values   = ["sts.amazonaws.com"]
     }
+
+    dynamic "condition" {
+      for_each = var.additional_conditions
+      content {
+        test     = condition.value.test
+        variable = condition.value.variable
+        values   = condition.value.values
+      }
+    }
   }
 }
 

--- a/modules/github-oidc-role/variables.tf
+++ b/modules/github-oidc-role/variables.tf
@@ -32,6 +32,16 @@ variable "max_session_duration" {
   default     = 3600
 }
 
+variable "additional_conditions" {
+  description = "Additional conditions for the OIDC trust policy, e.g. job_workflow_ref restrictions"
+  type = list(object({
+    test     = string
+    variable = string
+    values   = list(string)
+  }))
+  default = []
+}
+
 variable "ecr_push_policy" {
   description = "ECR push policy configuration for GitHub Actions OIDC role"
   type = object({


### PR DESCRIPTION
  ### Summary
  - Adds `additional_conditions` variable to `github-oidc-role` module — accepts a list of condition blocks appended to
   the existing `sub` and `aud` conditions in the trust policy
  - Implemented via a `dynamic "condition"` block, so the default (`[]`) is fully backwards-compatible with all
  existing module usages

  ### Use case
  Enables restricting an OIDC role to a specific workflow file via `job_workflow_ref`:
  ```hcl
  additional_conditions = [
    {
      test     = "StringLike"
      variable = "token.actions.githubusercontent.com:job_workflow_ref"
      values   = ["org/repo/.github/workflows/deploy.yml@refs/heads/master"]
    }
  ]
  This ensures the role can only be assumed by that specific workflow, not any workflow in the repository.